### PR TITLE
Fix title not displayed

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -271,7 +271,7 @@ module.exports = function (moduleOptions) {
 			options.title = this.options.head.title
 		}
 
-		this.options.title = createTitle(options)
+		this.options.head.title = createTitle(options)
 		this.options.head.meta = createMeta(options, this.options.head.meta, template)
 
 		const pluginOptions = {


### PR DESCRIPTION
## Problem

The title is not set in the browser (`<title></title>` missing) even though seo.name, seo.title and seo.templateTitle is set in `nuxt.config.js`.

## Solution
This merge request fixes the bug. The title was  set to `this.options.title` instead of `this.options.head.title`.

Fixes #71.
Thanks for merging and releasing a new version :)