### PR TITLE
Fix nuxt.config.js head.link overridden

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -289,7 +289,7 @@ module.exports = function (moduleOptions) {
 
 		this.options.head.title = createTitle(options)
 		this.options.head.meta = createMeta(options, this.options.head.meta, template)
-		this.options.head.link = createCanonical(options, '/')
+		this.options.head.link = createCanonical(options, '/').concat(this.options.head.link || []);
 
 		const pluginOptions = {
 			moduleOptions: options,


### PR DESCRIPTION
Instead of replacing the existing links, this fix makes sure that the Canonical is appended to the existing links.

Fixes #78. 
