### PR TITLE
Fix 96 target static  duplicate meta tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,5 @@ typings/
 
 # Nuxt
 example/.nuxt
+example/.nuxtStatic
 dist/

--- a/example/nuxt.config.static.js
+++ b/example/nuxt.config.static.js
@@ -1,0 +1,13 @@
+const path = require('path')
+const baseConfig = require('./nuxt.config')
+
+const buildDir = path.resolve(__dirname, '.nuxtStatic')
+
+module.exports = {
+	...baseConfig,
+	generate: {
+		dir: `${buildDir}/_static`
+	},
+	buildDir,
+	target: 'static'
+}

--- a/lib/module.js
+++ b/lib/module.js
@@ -228,6 +228,7 @@ const createMeta = (options = {}, inputMeta = [], template = {}) => {
 						}
 
 						outputMeta.push({
+							hid: meta.id,
 							[id]: meta.value
 						})
 					})
@@ -240,6 +241,7 @@ const createMeta = (options = {}, inputMeta = [], template = {}) => {
 					}
 
 					outputMeta.push({
+						hid: meta.id,
 						[meta.id]: meta.value
 					})
 				}

--- a/lib/module.js
+++ b/lib/module.js
@@ -189,7 +189,7 @@ const createMeta = (options = {}, inputMeta = [], template = {}) => {
 				})
 			} else if (typeof meta.value === 'object' && !Array.isArray(meta.value)) {
 				return generate(meta, meta.value, meta.id + ':')
-			} else if (meta.content) {
+			} else {
 				findAndRemove(meta.id)
 
 				meta.value = parserValue(meta.value)
@@ -197,9 +197,11 @@ const createMeta = (options = {}, inputMeta = [], template = {}) => {
 					return
 				}
 
-				if (meta.ids) {
-					meta.ids.map(id => {
-						meta.id = id
+				metaIds = meta.ids || [meta.id]
+				metaIds.forEach(id => {
+					meta.id = id
+
+					if (meta.content) {
 						outputMeta.push({
 							hid: meta.id,
 							key: typeof index === 'number' ? `${meta.id}:0${index}` : meta.id,
@@ -207,44 +209,13 @@ const createMeta = (options = {}, inputMeta = [], template = {}) => {
 							name: meta.id,
 							content: meta.value
 						})
-					})
-				} else {
-					outputMeta.push({
-						hid: meta.id,
-						key: typeof index === 'number' ? `${meta.id}:0${index}` : meta.id,
-						property: meta.id,
-						name: meta.id,
-						content: meta.value
-					})
-				}
-			} else if (meta.id) {
-				if (meta.ids) {
-					meta.ids.map(id => {
-						findAndRemove(id)
-
-						meta.value = parserValue(meta.value)
-						if (!meta.value) {
-							return
-						}
-
+					} else {
 						outputMeta.push({
-							hid: meta.id,
+							hid: id,
 							[id]: meta.value
 						})
-					})
-				} else {
-					findAndRemove(meta.id)
-
-					meta.value = parserValue(meta.value)
-					if (!meta.value) {
-						return
 					}
-
-					outputMeta.push({
-						hid: meta.id,
-						[meta.id]: meta.value
-					})
-				}
+				})
 			}
 		})
 	}

--- a/lib/module.js
+++ b/lib/module.js
@@ -147,8 +147,9 @@ const createMeta = (options = {}, inputMeta = [], template = {}) => {
 
 	const generate = (metas, optionsGenerate, id = '', index = false) => {
 		metas = {...metas}
-		Object.keys(metas).map(k => {
-			const meta = {...metas[k]}
+		Object.keys(metas).forEach(k => {
+			const meta = {ids: false, ...metas[k]}
+			let metaIds
 			if (meta.fullId) {
 				meta.id = meta.fullId
 			} else if (!meta.id) { // eslint-disable-line no-negated-condition

--- a/test/fixtures/all.js
+++ b/test/fixtures/all.js
@@ -1,8 +1,11 @@
 module.exports = [{
+	hid: 'charset',
 	charset: 'utf-8'
 }, {
+	hid: 'lang',
 	lang: 'en'
 }, {
+	hid: 'language',
 	language: 'English'
 }, {
 	hid: 'copyright',

--- a/test/nuxt.js
+++ b/test/nuxt.js
@@ -1,7 +1,9 @@
 const test = require('ava')
-const {Nuxt, Builder} = require('nuxt')
+const {Nuxt, Builder, Generator} = require('nuxt')
+const fsPromises = require('fs').promises
 const got = require('got')
 const config = require('../example/nuxt.config')
+const configStatic = require('../example/nuxt.config.static')
 
 const url = path => `http://localhost:4000${path}`
 const get = async path => {
@@ -9,38 +11,72 @@ const get = async path => {
 	return body
 }
 
+const staticPath = path => `${configStatic.generate.dir}${path}index.html`
+const getStatic = async path => {
+	return fsPromises.readFile(staticPath(path), {encoding: 'utf8'})
+}
+
 let nuxt = null
 
 test.before('Init Nuxt.js', async () => {
+	// Init SSR
 	config.dev = false
 	config.seo.baseUrl = 'http://localhost:4000'
 	nuxt = new Nuxt(config)
 	await new Builder(nuxt).build()
-	nuxt.listen(4000, 'localhost')
+	await nuxt.listen(4000, 'localhost')
+
+	// Build STATIC
+	configStatic.dev = false
+	const nuxtStatic = new Nuxt(configStatic)
+	const builder = await new Builder(nuxtStatic)
+	const generator = await new Generator(nuxtStatic, builder)
+	await nuxtStatic.listen(4001, 'localhost')
+	const {errors} = await generator.generate({build: false})
+	if (errors.length > 0) {
+		throw new Error('Error generating pages, exiting with non-zero code')
+	}
+
+	await nuxtStatic.close()
 })
 
 test.after('Closing server', () => {
 	nuxt.close()
 })
 
+test('Static route /', async t => {
+	const html = await getStatic('/')
+	t.true(html.includes('<title>Home Page</title>'))
+	t.true(html.match('<meta data-n-head="ssr" data-hid="charset" charset="utf-8">').length === 1)
+})
+
+test('Static route /news', async t => {
+	const html = await getStatic('/news/')
+	t.true(html.includes('<title>Nuxt is the best</title>'))
+	t.true(html.match('<meta data-n-head="ssr" data-hid="charset" charset="utf-8">').length === 1)
+})
+
 test('Route / and render HTML', async t => {
 	const html = await get('/')
 
 	t.true(html.includes('<title>Home Page</title>'))
-	t.true(html.includes('<meta data-n-head="ssr" charset="utf-8"'))
-	t.true(html.includes('<meta data-n-head="ssr" lang="en">'))
-	t.true(html.includes('<meta data-n-head="ssr" language="English">'))
+	t.true(html.match('<meta data-n-head="ssr" data-hid="charset" charset="utf-8">').length === 1)
+	t.true(html.includes('<meta data-n-head="ssr" data-hid="charset" charset="utf-8"'))
+	t.true(html.includes('<meta data-n-head="ssr" data-hid="lang" lang="en">'))
+	t.true(html.includes('<meta data-n-head="ssr" data-hid="language" language="English">'))
 	t.true(html.includes('<meta data-n-head="ssr" data-hid="name" key="name" property="name" name="name" content="App name">'))
 	t.true(html.includes('<meta data-n-head="ssr" data-hid="description" key="description" property="description" name="description" content="Example app with Nuxt Seo">'))
 	t.true(html.includes('<link data-n-head="ssr" rel="canonical" href="http://localhost:4000/">'))
 })
 
 test('Route /news and render HTML', async t => {
+	await get('/news')
+	await get('/')
 	const html = await get('/news')
 	t.true(html.includes('<title>Nuxt is the best</title>'))
-	t.true(html.includes('<meta data-n-head="ssr" charset="utf-8">'))
-	t.true(html.includes('<meta data-n-head="ssr" lang="en">'))
-	t.true(html.includes('<meta data-n-head="ssr" language="English">'))
+	t.true(html.match('<meta data-n-head="ssr" data-hid="charset" charset="utf-8">').length === 1)
+	t.true(html.includes('<meta data-n-head="ssr" data-hid="lang" lang="en">'))
+	t.true(html.includes('<meta data-n-head="ssr" data-hid="language" language="English">'))
 	t.true(html.includes('<meta data-n-head="ssr" data-hid="name" key="name" property="name" name="name" content="App name">'))
 	t.true(html.includes('<meta data-n-head="ssr" data-hid="description" key="description" property="description" name="description" content="Hello World page in blog">'))
 	t.true(html.includes('<meta data-n-head="ssr" data-hid="og:site_name" key="og:site_name" property="og:site_name" name="og:site_name" content="App name">'))


### PR DESCRIPTION
Fix for issue https://github.com/TiagoDanin/Nuxt-SEO/issues/96

Added proposed "fix": no-content meta tags get the attribute 'hid' set

Updated existing tests to fit new generated sources.
Added additional test for SSR served sources to check for duplicate no-content meta tags (there were non - SSR seems not to have suffered from this issue)
Added new test to also test static generated sources for duplicate no-content meta tags.

In addition I refactored the `generate` function a little to keep it DRY.

PS: many thanks for this plugin. Makes SEO a breeze 